### PR TITLE
Fixed .AddBody overloads so that the correct one is picked for byte[]…

### DIFF
--- a/http/RestRequest.cs
+++ b/http/RestRequest.cs
@@ -39,7 +39,11 @@ namespace RESTClient {
       this.AddBody(bytes, contentType, false);
     }
 
-    public void AddBody(byte[] bytes, string contentType, bool isChunked = false) {
+    public void AddBody(byte[] bytes, string contentType) {
+      this.AddBody(bytes, contentType, false);
+    }
+
+    public void AddBody(byte[] bytes, string contentType, bool isChunked) {
       if (Request.uploadHandler != null) {
         Debug.LogWarning("Request body can only be set once");
         return;


### PR DESCRIPTION
This PR addresses some cases reported earlier. Namely, whenever there's a `byte[]` scenario for uploading blobs the wrong overload is being picked by the compiler (generic one, which tries to make a JSON out of those bytes) and it fails.

It was introduced along with the optional parameter for the `.AddBody` method for `byte[]`. 

I've added a new overload that fixes the issue. 

Fixes: https://github.com/Unity3dAzure/RESTClient/issues/4