### PR TITLE
Update WWW with UnityWebRequest

### DIFF
--- a/http/QueryParams.cs
+++ b/http/QueryParams.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using UnityEngine.Networking;
 
 namespace RESTClient {
   public class QueryParams {
@@ -26,8 +27,8 @@ namespace RESTClient {
       }
       StringBuilder sb = new StringBuilder("?");
       foreach (KeyValuePair<string, string> param in parameters) {
-        string key = WWW.EscapeURL(param.Key);
-        string value = WWW.EscapeURL(param.Value);
+        string key = UnityWebRequest.EscapeURL(param.Key);
+        string value = UnityWebRequest.EscapeURL(param.Value);
         sb.Append(key + "=" + value + "&");
       }
       sb.Remove(sb.Length - 1, 1);

--- a/http/RestRequest.cs
+++ b/http/RestRequest.cs
@@ -36,11 +36,7 @@ namespace RESTClient {
 
     public void AddBody(string text, string contentType = "text/plain; charset=UTF-8") {
       byte[] bytes = Encoding.UTF8.GetBytes(text);
-      this.AddBody(bytes, contentType, false);
-    }
-
-    public void AddBody(byte[] bytes, string contentType) {
-      this.AddBody(bytes, contentType, false);
+      this.AddBody(bytes, contentType);
     }
 
     public void AddBody(byte[] bytes, string contentType) {
@@ -59,7 +55,7 @@ namespace RESTClient {
       }
       string jsonString = JsonUtility.ToJson(data);
       byte[] bytes = Encoding.UTF8.GetBytes(jsonString);
-      this.AddBody(bytes, contentType, false);
+      this.AddBody(bytes, contentType);
     }
 
     public virtual void AddQueryParam(string key, string value, bool shouldUpdateRequestUrl = false) {

--- a/http/RestRequest.cs
+++ b/http/RestRequest.cs
@@ -43,12 +43,11 @@ namespace RESTClient {
       this.AddBody(bytes, contentType, false);
     }
 
-    public void AddBody(byte[] bytes, string contentType, bool isChunked) {
+    public void AddBody(byte[] bytes, string contentType) {
       if (Request.uploadHandler != null) {
         Debug.LogWarning("Request body can only be set once");
         return;
       }
-      Request.chunkedTransfer = isChunked;
       Request.uploadHandler = new UploadHandlerRaw(bytes);
       Request.uploadHandler.contentType = contentType;
     }


### PR DESCRIPTION
WWW is marked as obsolete. Replace it with the updated UnityWebRequest.
https://docs.unity3d.com/ja/current/ScriptReference/WWW.html